### PR TITLE
fix: faster loads on request page, update balance on all screen 

### DIFF
--- a/src/frontend/hooks/useHasRewards.js
+++ b/src/frontend/hooks/useHasRewards.js
@@ -42,7 +42,13 @@ const useHasRewards = (childId, revokeCalls = false) => {
     return () => clearInterval(intervalId);
   }, []);
 
-  return { count, prevCount, hasNewData: count !== prevCount };
+  return {
+    count,
+    prevCount,
+    hasNewData: count !== prevCount,
+    reqCount: count,
+    setReqCount: setCount,
+  };
 };
 
 export default useHasRewards;

--- a/src/frontend_kids/components/BottomNav/BottomTabNav.jsx
+++ b/src/frontend_kids/components/BottomNav/BottomTabNav.jsx
@@ -5,7 +5,6 @@ import {
   Flex,
   TabList,
   Tabs,
-  useDisclosure,
   useMultiStyleConfig,
   useTab,
 } from "@chakra-ui/react";

--- a/src/frontend_kids/components/Rewards/ChildReward.jsx
+++ b/src/frontend_kids/components/Rewards/ChildReward.jsx
@@ -13,7 +13,7 @@ const ChildReward = ({
   handleSetGoal,
 }) => {
   const [showEmoji, setShowEmoji] = useState(false);
-  const { isOpen, onToggle } = useDisclosure();
+  const [isOpen, setIsOpen] = useState(false);
 
   const handleClick = (reward, state) => {
     switch (state) {
@@ -28,10 +28,10 @@ const ChildReward = ({
         break;
     }
     setShowEmoji(true);
-    onToggle(); // trigger animation
+    setIsOpen(true); // trigger animation
     setTimeout(() => {
       setShowEmoji(false);
-      onToggle(); // end animation
+      setIsOpen(false); // end animation
     }, 2000); // display for 2 second
   };
 

--- a/src/frontend_kids/components/Tasks/ChildTask.jsx
+++ b/src/frontend_kids/components/Tasks/ChildTask.jsx
@@ -6,15 +6,16 @@ import { ScaleFade } from "@chakra-ui/react";
 
 const ChildTask = ({ task, handleReq }) => {
   const [showEmoji, setShowEmoji] = useState(false);
-  const { isOpen, onToggle } = useDisclosure();
+  const [isOpen, setIsOpen] = useState(false);
 
   const handleClick = (task) => {
-    handleReq(task);
     setShowEmoji(true);
-    onToggle();
+    handleReq(task);
+    setIsOpen(true);
+
     setTimeout(() => {
       setShowEmoji(false);
-      onToggle();
+      setIsOpen(false);
     }, 2000);
   };
 

--- a/src/frontend_kids/screens/Rewards.jsx
+++ b/src/frontend_kids/screens/Rewards.jsx
@@ -37,7 +37,7 @@ const Rewards = () => {
 
   React.useEffect(() => {
     if (!blockingChildUpdate) {
-      getChildren({});
+      getChildren({ revokeStateUpdate: true });
     }
   }, []);
 

--- a/src/frontend_kids/screens/Tasks.jsx
+++ b/src/frontend_kids/screens/Tasks.jsx
@@ -29,7 +29,7 @@ const Tasks = () => {
 
   React.useEffect(() => {
     if (!blockingChildUpdate) {
-      getChildren({ revokeStateUpdate: false });
+      getChildren({ revokeStateUpdate: true });
     }
   }, []);
 

--- a/src/frontend_kids/screens/Wallet.jsx
+++ b/src/frontend_kids/screens/Wallet.jsx
@@ -60,11 +60,11 @@ const Wallet = () => {
             get(`selectedChildName`, store),
           ]);
           if (data) {
-            setChild({
-              id: data,
-              balance: parseInt(balance),
-              name,
-            });
+            // setChild({
+            //   id: data,
+            //   balance: parseInt(balance),
+            //   name,
+            // });
           } else {
             navigate("/");
           }


### PR DESCRIPTION
Changes include,

- Make it so that if the data in the kids app refreshes, then the balance updates in all screens.

- Approving / declining a request was slow - can we make quick for the parent to do a few.

- Goal on header not updatingm in kids app.
